### PR TITLE
Improve checkout performance

### DIFF
--- a/includes/class-mojito-shipping.php
+++ b/includes/class-mojito-shipping.php
@@ -270,6 +270,11 @@ class Mojito_Shipping {
                  */
                 add_action( 'wp_ajax_mojito_shipping_ccr_manual_register_guide_number', array($this, 'ccr_manual_register') );
                 /**
+                 * Ajax Guide number request for checkout
+                 */
+                add_action( 'wp_ajax_mojito_shipping_ccr_get_guide_number', array($this, 'ccr_ajax_get_guide_number') );
+                add_action( 'wp_ajax_nopriv_mojito_shipping_ccr_get_guide_number', array($this, 'ccr_ajax_get_guide_number') );
+                /**
                  * Download PDF from admin
                  */
                 add_action( 'wp_ajax_mojito_shipping_ccr_download_pdf', array($this, 'ccr_pdf_download') );
@@ -356,7 +361,6 @@ class Mojito_Shipping {
         woocommerce_form_field( 'mojito_shipping_ccr_guide_number', array(
             'type'              => 'text',
             'class'             => array('hidden'),
-            'default'           => $this->ccr_ws_client->ccr_get_guide_number(),
             'custom_attributes' => array(
                 'readonly' => 'readonly',
             ),
@@ -649,6 +653,19 @@ class Mojito_Shipping {
             }
         }
         die;
+    }
+
+    /**
+     * Ajax handler: return CCR guide number
+     *
+     * @return void
+     */
+    public function ccr_ajax_get_guide_number() {
+        $guide_number = $this->ccr_ws_client->ccr_get_guide_number();
+        wp_send_json( array(
+            'success'      => ! empty( $guide_number ),
+            'guide_number' => $guide_number,
+        ) );
     }
 
     /**

--- a/public/class-mojito-shipping-public.php
+++ b/public/class-mojito-shipping-public.php
@@ -99,14 +99,12 @@ class Mojito_Shipping_Public {
 		 * class.
 		 */
 
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/mojito-shipping-public.js', array( 'jquery' ), $this->version, false );
+               wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/mojito-shipping-public.js', array( 'jquery' ), $this->version, false );
 
-		if ( 'yes' === get_option( 'mojito-shipping-ccr-pdf-export-in-customer-order' ) ) {
-			wp_localize_script(
-				$this->plugin_name,
-				'mojito_ajax',
-				array( 'ajax_url' => admin_url( 'admin-ajax.php' ) )
-			);
-		}
+               wp_localize_script(
+                       $this->plugin_name,
+                       'mojito_ajax',
+                       array( 'ajax_url' => admin_url( 'admin-ajax.php' ) )
+               );
 	}
 }

--- a/public/js/mojito-shipping-public.js
+++ b/public/js/mojito-shipping-public.js
@@ -1,5 +1,23 @@
 (function( $ ) {
-	'use strict';
+        'use strict';
+
+        $( function() {
+                var field = $( '#mojito_shipping_ccr_guide_number' );
+                if ( field.length && typeof mojito_ajax !== 'undefined' ) {
+                        $.post(
+                                mojito_ajax.ajax_url,
+                                { action: 'mojito_shipping_ccr_get_guide_number' },
+                                function( response ) {
+                                        try {
+                                                var data = JSON.parse( response );
+                                                if ( data.success ) {
+                                                        field.val( data.guide_number );
+                                                }
+                                        } catch (e) {}
+                                }
+                        );
+                }
+        });
 
 	 $(document).on('click', '.mojito-shipping-toggle-tracking', function(event) {
 		 event.preventDefault();


### PR DESCRIPTION
## Summary
- load frontend JS ajax helper on all pages
- request Correos de Costa Rica guide number via AJAX instead of blocking checkout

## Testing
- `composer install`
- `php -l includes/class-mojito-shipping.php`
- `php -l public/class-mojito-shipping-public.php`

------
https://chatgpt.com/codex/tasks/task_e_6883d5d942f4832abeae4296fc23e006