### PR TITLE
Improve error logging and AJAX handling

### DIFF
--- a/includes/class-mojito-shipping-method-ccr-webservice-client.php
+++ b/includes/class-mojito-shipping-method-ccr-webservice-client.php
@@ -453,18 +453,32 @@ class Mojito_Shipping_Method_CCR_WSC {
                 'error'  => $e,
                 'libxml' => libxml_get_last_error(),
             ) );
-            echo __( 'There was an error with Correos de Costa Rica: ', 'mojito-shipping' ) . $e->getMessage() . "\n";
-            echo '<a href="https://mojitowp.com/documentacion/sistema-saliente/#3.11">' . __( 'Checkout this documentation.', 'mojito-shipping' ) . '</a>';
+            $message = __( 'There was an error with Correos de Costa Rica: ', 'mojito-shipping' ) . $e->getMessage();
             $this->log( sprintf( 'Error in service query: %s', $e->getMessage() ) );
+            if ( function_exists( 'wc_get_logger' ) ) {
+                wc_get_logger()->error( $message, array( 'source' => 'mojito-shipping-ccr' ) );
+            } else {
+                error_log( $message );
+            }
+            if ( wp_doing_ajax() ) {
+                wp_send_json_error( $message );
+            }
         } catch ( \SoapFault $s ) {
             $result = -1;
             mojito_shipping_debug( array(
                 'error'  => $e,
                 'libxml' => libxml_get_last_error(),
             ) );
-            echo __( 'There was an error with Correos de Costa Rica: ', 'mojito-shipping' ) . $s->getMessage() . "\n";
-            echo '<a href="https://mojitowp.com/documentacion/sistema-saliente/#3.11">' . __( 'Checkout this documentation.', 'mojito-shipping' ) . '</a>';
+            $message = __( 'There was an error with Correos de Costa Rica: ', 'mojito-shipping' ) . $s->getMessage();
             $this->log( sprintf( 'Error in service query: %s', $s->getMessage() ) );
+            if ( function_exists( 'wc_get_logger' ) ) {
+                wc_get_logger()->error( $message, array( 'source' => 'mojito-shipping-ccr' ) );
+            } else {
+                error_log( $message );
+            }
+            if ( wp_doing_ajax() ) {
+                wp_send_json_error( $message );
+            }
         }
         return $result;
     }

--- a/includes/class-mojito-shipping-method-pymexpress-webservice-client.php
+++ b/includes/class-mojito-shipping-method-pymexpress-webservice-client.php
@@ -162,9 +162,16 @@ class Mojito_Shipping_Method_Pymexpress_WSC {
             mojito_shipping_debug( $response );
             mojito_shipping_debug( $info );
             mojito_shipping_debug( $err );
-            echo sprintf( __( 'There was an error with Correos de Costa Rica: %s', 'mojito-shipping' ), $err ) . "\n";
-            echo '<a href="https://mojitowp.com/documentacion/pymexpress/#3.11">' . __( 'Checkout this documentation.', 'mojito-shipping' ) . '</a>';
+            $message = sprintf( __( 'There was an error with Correos de Costa Rica: %s', 'mojito-shipping' ), $err );
             $this->log( 'error', sprintf( 'Error in auth query: %s', $err ) );
+            if ( function_exists( 'wc_get_logger' ) ) {
+                wc_get_logger()->error( $message, array( 'source' => 'mojito-shipping-pymexpress' ) );
+            } else {
+                error_log( $message );
+            }
+            if ( wp_doing_ajax() ) {
+                wp_send_json_error( $message );
+            }
         } else {
             if ( empty( $response ) ) {
                 mojito_shipping_debug( __( 'Authentication issues.', 'mojito-shipping' ) );
@@ -894,9 +901,16 @@ class Mojito_Shipping_Method_Pymexpress_WSC {
         mojito_shipping_debug( $method . ' ejectutado en ' . $this->environment['process_url'] );
         $err = curl_error( $curl );
         if ( $err ) {
-            echo sprintf( __( 'There was an error with Correos de Costa Rica: %s', 'mojito-shipping' ), $err ) . "\n";
-            echo '<a href="https://mojitowp.com/documentacion/pymexpress/#3.11">' . __( 'Checkout this documentation.', 'mojito-shipping' ) . '</a>';
+            $message = sprintf( __( 'There was an error with Correos de Costa Rica: %s', 'mojito-shipping' ), $err );
             $this->log( 'error', sprintf( 'Error in service query: %s', $err ) );
+            if ( function_exists( 'wc_get_logger' ) ) {
+                wc_get_logger()->error( $message, array( 'source' => 'mojito-shipping-pymexpress' ) );
+            } else {
+                error_log( $message );
+            }
+            if ( wp_doing_ajax() ) {
+                wp_send_json_error( $message );
+            }
             return;
         }
         // SimpleXML seems to have problems with the colon ":" in the <xxx:yyy> response tags, so take them out.


### PR DESCRIPTION
## Summary
- log errors instead of echoing in Pymexpress webservice client
- log errors instead of echoing in CCR webservice client
- send JSON errors during AJAX requests

## Testing
- `composer install`
- `php -l includes/class-mojito-shipping-method-pymexpress-webservice-client.php`
- `php -l includes/class-mojito-shipping-method-ccr-webservice-client.php`


------
https://chatgpt.com/codex/tasks/task_e_6883f1add13c832a8595f141fa90e030