### PR TITLE
Add nonce and capability checks for manual AJAX actions

### DIFF
--- a/admin/class-mojito-shipping-admin.php
+++ b/admin/class-mojito-shipping-admin.php
@@ -78,6 +78,15 @@ class Mojito_Shipping_Admin extends Mojito_Settings {
             MOJITO_SHIPPING_VERSION,
             false
         );
+
+        wp_localize_script(
+            MOJITO_SHIPPING_SLUG,
+            'mojito_shipping_admin_ajax',
+            array(
+                'ajax_url' => admin_url( 'admin-ajax.php' ),
+                'nonce'    => wp_create_nonce( 'mojito_shipping_admin_nonce' ),
+            )
+        );
     }
 
     /**

--- a/admin/js/mojito-shipping-admin.js
+++ b/admin/js/mojito-shipping-admin.js
@@ -135,16 +135,17 @@
 
 		var order_id = $(this).attr('id');
 
-		var data = {
-			action: 'mojito_shipping_ccr_manual_request_guide_number',			
-			order_id: order_id,
-		};
+                var data = {
+                        action: 'mojito_shipping_ccr_manual_request_guide_number',
+                        order_id: order_id,
+                        security: mojito_shipping_admin_ajax.nonce,
+                };
 
-		$.post('admin-ajax.php', data, function (response) {
-			if (response == 'true') {
-				location.reload();
-			}
-		});
+                $.post(mojito_shipping_admin_ajax.ajax_url, data, function (response) {
+                        if (response == 'true') {
+                                location.reload();
+                        }
+                });
 	});
 
 	/*
@@ -159,16 +160,17 @@
 
 		var order_id = $(this).attr('id');
 
-		var data = {
-			action: 'mojito_shipping_pymexpress_manual_request_guide_number',
-			order_id: order_id,
-		};
+                var data = {
+                        action: 'mojito_shipping_pymexpress_manual_request_guide_number',
+                        order_id: order_id,
+                        security: mojito_shipping_admin_ajax.nonce,
+                };
 
-		$.post('admin-ajax.php', data, function (response) {
-			if (response == 'true') {
-				location.reload();
-			}
-		});
+                $.post(mojito_shipping_admin_ajax.ajax_url, data, function (response) {
+                        if (response == 'true') {
+                                location.reload();
+                        }
+                });
 	});
 
 
@@ -184,16 +186,17 @@
 
 		var order_id = $(this).attr('id');
 
-		var data = {
-			action: 'mojito_shipping_ccr_manual_register_guide_number',
-			order_id: order_id,
-		};
+                var data = {
+                        action: 'mojito_shipping_ccr_manual_register_guide_number',
+                        order_id: order_id,
+                        security: mojito_shipping_admin_ajax.nonce,
+                };
 
-		$.post('admin-ajax.php', data, function (response) {
-			if (response == 'true') {
-				location.reload();
-			}
-		});
+                $.post(mojito_shipping_admin_ajax.ajax_url, data, function (response) {
+                        if (response == 'true') {
+                                location.reload();
+                        }
+                });
 	});
 
 	/*
@@ -208,16 +211,17 @@
 
 		var order_id = $(this).attr('id');
 
-		var data = {
-			action: 'mojito_shipping_pymexpress_manual_register_guide_number',
-			order_id: order_id,
-		};
+                var data = {
+                        action: 'mojito_shipping_pymexpress_manual_register_guide_number',
+                        order_id: order_id,
+                        security: mojito_shipping_admin_ajax.nonce,
+                };
 
-		$.post('admin-ajax.php', data, function (response) {
-			if (response == 'true') {
-				location.reload();
-			}
-		});
+                $.post(mojito_shipping_admin_ajax.ajax_url, data, function (response) {
+                        if (response == 'true') {
+                                location.reload();
+                        }
+                });
 	});
 
 	/*

--- a/includes/class-mojito-shipping.php
+++ b/includes/class-mojito-shipping.php
@@ -610,11 +610,15 @@ class Mojito_Shipping {
      * Useful when guide number request fail during the shopping
      */
     public function ccr_manual_request() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            wp_die();
+        }
+        check_ajax_referer( 'mojito_shipping_admin_nonce', 'security' );
         if ( isset( $_POST['order_id'] ) ) {
             $order_id = sanitize_text_field( $_POST['order_id'] );
             if ( !is_numeric( $order_id ) ) {
                 echo wp_json_encode( false );
-                die;
+                wp_die();
             }
             $guide_number = $this->ccr_ws_client->ccr_get_guide_number();
             $order = wc_get_order( $order_id );
@@ -623,36 +627,40 @@ class Mojito_Shipping {
             $comment_id = $this->ccr_thankyou_log_send( $order_id, true );
             if ( is_numeric( $comment_id ) ) {
                 echo wp_json_encode( true );
-                die;
+                wp_die();
             } else {
                 echo wp_json_encode( false );
-                die;
+                wp_die();
             }
         }
-        die;
+        wp_die();
     }
 
     /**
      * Manual register
      * Useful when register process fail during the shopping
-     */
+    */
     public function ccr_manual_register() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            wp_die();
+        }
+        check_ajax_referer( 'mojito_shipping_admin_nonce', 'security' );
         if ( isset( $_POST['order_id'] ) ) {
             $order_id = sanitize_text_field( $_POST['order_id'] );
             if ( !is_numeric( $order_id ) ) {
                 echo wp_json_encode( false );
-                die;
+                wp_die();
             }
             $comment_id = $this->ccr_thankyou_log_send( $order_id, true );
             if ( is_numeric( $comment_id ) ) {
                 echo wp_json_encode( true );
-                die;
+                wp_die();
             } else {
                 echo wp_json_encode( false );
-                die;
+                wp_die();
             }
         }
-        die;
+        wp_die();
     }
 
     /**
@@ -674,12 +682,12 @@ class Mojito_Shipping {
      */
     public function ccr_pdf_download() {
         if ( empty( $_POST['order_id'] ) ) {
-            die;
+            wp_die();
         }
         $order_id = sanitize_text_field( $_POST['order_id'] );
         if ( !is_numeric( $order_id ) ) {
             echo wp_json_encode( false );
-            die;
+            wp_die();
         }
         /**
          * Validate order
@@ -1163,7 +1171,7 @@ class Mojito_Shipping {
             'guide_number' => $guide_number,
         ) );
         wp_delete_file( $file );
-        die;
+        wp_die();
     }
 
     /**
@@ -1523,13 +1531,17 @@ class Mojito_Shipping {
     /**
      * Manual request
      * Useful when guide number request fail during the shopping
-     */
+    */
     public function pymexpress_manual_request() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            wp_die();
+        }
+        check_ajax_referer( 'mojito_shipping_admin_nonce', 'security' );
         if ( isset( $_POST['order_id'] ) ) {
             $order_id = sanitize_text_field( $_POST['order_id'] );
             if ( !is_numeric( $order_id ) ) {
                 echo wp_json_encode( false );
-                die;
+                wp_die();
             }
             $guide_number = $this->pymexpress_ws_client->generar_guia();
             $order = wc_get_order( $order_id );
@@ -1538,36 +1550,40 @@ class Mojito_Shipping {
             $comment_id = $this->pymexpress_thankyou_log_send( $order_id, true );
             if ( is_numeric( $comment_id ) ) {
                 echo wp_json_encode( true );
-                die;
+                wp_die();
             } else {
                 echo wp_json_encode( false );
-                die;
+                wp_die();
             }
         }
-        die;
+        wp_die();
     }
 
     /**
      * Manual register
      * Useful when register process fail during the shopping
-     */
+    */
     public function pymexpress_manual_register() {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            wp_die();
+        }
+        check_ajax_referer( 'mojito_shipping_admin_nonce', 'security' );
         if ( isset( $_POST['order_id'] ) ) {
             $order_id = sanitize_text_field( $_POST['order_id'] );
             if ( !is_numeric( $order_id ) ) {
                 echo wp_json_encode( false );
-                die;
+                wp_die();
             }
             $comment_id = $this->pymexpress_thankyou_log_send( $order_id, true );
             if ( is_numeric( $comment_id ) ) {
                 echo wp_json_encode( true );
-                die;
+                wp_die();
             } else {
                 echo wp_json_encode( false );
-                die;
+                wp_die();
             }
         }
-        die;
+        wp_die();
     }
 
     /**
@@ -1579,13 +1595,13 @@ class Mojito_Shipping {
         if ( empty( $order_id ) ) {
             $ajax_call = true;
             if ( empty( $_POST['order_id'] ) ) {
-                die;
+                wp_die();
             }
             $order_id = sanitize_text_field( $_POST['order_id'] );
         }
         if ( !is_numeric( $order_id ) ) {
             echo wp_json_encode( false );
-            die;
+            wp_die();
         }
         /**
          * Validate order
@@ -2087,7 +2103,7 @@ class Mojito_Shipping {
         if ( $ajax_call ) {
             echo wp_json_encode( $response );
             wp_delete_file( $file );
-            die;
+            wp_die();
         } else {
             $response['path'] = $file;
             return $response;


### PR DESCRIPTION
## Summary
- secure manual AJAX endpoints with nonce checks and capability verification
- use `wp_die()` instead of raw `die`
- localize admin script with nonce and update AJAX requests to send it

## Testing
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_6883f1ae85d0832ab005a8648230e1ef