### PR TITLE
Remove extraneous return

### DIFF
--- a/includes/class-mojito-shipping-address.php
+++ b/includes/class-mojito-shipping-address.php
@@ -149,7 +149,6 @@ class Mojito_Shipping_Address {
             'canton'   => $canton_id,
             'district' => $distric_id,
         );
-        return array();
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove duplicate `return array()` in `find_location_using_postcode()`

## Testing
- `php -l includes/class-mojito-shipping-address.php`

------
https://chatgpt.com/codex/tasks/task_e_6883f1b0181c832a988b7e572ac1a1b0